### PR TITLE
rename port method

### DIFF
--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -30,7 +30,7 @@ class Ssh
         return $this;
     }
 
-    public function port(int $port): self
+    public function usePort(int $port): self
     {
         $this->port = $port;
 

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -54,7 +54,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_set_the_port_via_the_dedicated_function()
     {
-        $command = (new Ssh('user', 'example.com'))->port(123)->getSshCommand('whoami');
+        $command = (new Ssh('user', 'example.com'))->usePort(123)->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }


### PR DESCRIPTION
The documentation says that one can change the port number via the`usePort()` method. However, there's no such method in the source code.

Rather than changing the docs and, by following the same approach/convention as the `usePublicKey()` method, then (despite BC break) I guess the `port` method should be renamed to `usePort()`.

