### PR TITLE
Port method compatibility with README

### DIFF
--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -30,7 +30,7 @@ class Ssh
         return $this;
     }
 
-    public function port(int $port): self
+    public function usePort(int $port): self
     {
         $this->port = $port;
 

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -54,7 +54,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_set_the_port_via_the_dedicated_function()
     {
-        $command = (new Ssh('user', 'example.com'))->port(123)->getSshCommand('whoami');
+        $command = (new Ssh('user', 'example.com'))->usePort(123)->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }


### PR DESCRIPTION
in the code, you named `port` method and `usePort` in the README