### PR TITLE
Add static create method

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 You can execute an SSH command like this:
 
 ```php
-(new Ssh('user', 'host'))->execute('your favorite command');
+Ssh::create('user', 'host')->execute('your favorite command');
 ```
 
 It will return an instance of [Symfony's `Process`](https://symfony.com/doc/current/components/process.html).
@@ -26,7 +26,7 @@ composer require spatie/ssh
 You can execute an SSH command like this:
 
 ```php
-$process = (new Ssh('user', 'host'))->execute('your favorite command');
+$process = Ssh::create('user', 'host')->execute('your favorite command');
 ```
 
 It will return an instance of [Symfony's `Process`](https://symfony.com/doc/current/components/process.html).
@@ -52,7 +52,7 @@ $process->getOutput();
 To run multiple commands pass an array to the execute method.
 
 ```php
-$process = (new Ssh('user', 'host'))->execute([
+$process = Ssh::create('user', 'host')->execute([
    'first command',
    'second command',
 ]);
@@ -66,13 +66,13 @@ You can choose a port by passing it to the constructor.
 ```php
 $port = 123;
 
-(new Ssh('user', 'host', $port));
+Ssh::create('user', 'host', $port);
 ```
 
 Alternatively you can use the `port` function:
 
 ```php
-(new Ssh('user', 'host'))->usePort($port);
+Ssh::create('user', 'host')->usePort($port);
 ```
 
 
@@ -81,7 +81,7 @@ Alternatively you can use the `port` function:
 You can use `usePrivateKey` to specify a path to a private SSH key to use.
 
 ```php
-(new Ssh('user', 'host'))->usePrivateKey('/home/user/.ssh/id_rsa');
+Ssh::create('user', 'host')->usePrivateKey('/home/user/.ssh/id_rsa');
 ```
 
 ### Testing

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -23,6 +23,11 @@ class Ssh
         $this->port = $port;
     }
 
+    public static function create(...$args)
+    {
+        return new static(...$args);
+    }
+
     public function usePrivateKey(string $pathToPrivateKey): self
     {
         $this->pathToPrivateKey = $pathToPrivateKey;

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -23,7 +23,7 @@ class Ssh
         $this->port = $port;
     }
 
-    public static function create(...$args)
+    public static function create(...$args) : self
     {
         return new static(...$args);
     }

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -23,7 +23,7 @@ class Ssh
         $this->port = $port;
     }
 
-    public static function create(...$args) : self
+    public static function create(...$args): self
     {
         return new static(...$args);
     }

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -58,4 +58,10 @@ class SshTest extends TestCase
 
         $this->assertMatchesSnapshot($command);
     }
+
+    /** @test */
+    public function it_can_instantiate_via_the_create_method()
+    {
+        $this->assertInstanceOf(Ssh::class, Ssh::create('user', 'example.com'));
+    }
 }


### PR DESCRIPTION
It might be only me, but I've always disliked chaning directly to a new call:

```php
(new Ssh($arg))->function();
```
I normally use facades to get over this, but you can't quite do it here because the class is configured from the constructor (you could use the fluent API to define each setting separately, but I'm guessing that kind of defeats the whole purpose?). In this PR, I introduce a `::create()` method that just acts as a proxy to the constructor.

If this gets accepted, I can also PR the same change to the Docker package :)