### PR TITLE
Disable strict host key checking by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ You can use `usePrivateKey` to specify a path to a private SSH key to use.
 Ssh::create('user', 'host')->usePrivateKey('/home/user/.ssh/id_rsa');
 ```
 
+### Strict host key checking
+
+By default, strict host key checking is disabled. If you need more security you can enable strict host key checking using `enableStrictHostKeyChecking`.
+
+```php
+Ssh::create('user', 'host')->enableStrictHostKeyChecking();
+```
+
 ## Testing
 
 ``` bash

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -14,6 +14,8 @@ class Ssh
 
     private ?int $port;
 
+    private bool $enableStrictHostChecking = false;
+
     public function __construct(string $user, string $host, int $port = null)
     {
         $this->user = $user;
@@ -38,6 +40,13 @@ class Ssh
     public function usePort(int $port): self
     {
         $this->port = $port;
+
+        return $this;
+    }
+
+    public function enableStrictHostKeyChecking()
+    {
+        $this->enableStrictHostChecking = true;
 
         return $this;
     }
@@ -89,10 +98,7 @@ class Ssh
 
     protected function getExtraOptions(): string
     {
-        $extraOptions = [
-            "-o StrictHostKeyChecking=no",
-            "-o UserKnownHostsFile=/dev/null",
-        ];
+        $extraOptions = [];
 
         if ($this->pathToPrivateKey) {
             $extraOptions[] = "-i {$this->pathToPrivateKey}";
@@ -100,6 +106,11 @@ class Ssh
 
         if ($this->port) {
             $extraOptions[] = "-p {$this->port}";
+        }
+
+        if (! $this->enableStrictHostChecking) {
+            $extraOptions[] = "-o StrictHostKeyChecking=no";
+            $extraOptions[] = "-o UserKnownHostsFile=/dev/null";
         }
 
         return implode(' ', $extraOptions);

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -109,8 +109,8 @@ class Ssh
         }
 
         if (! $this->enableStrictHostChecking) {
-            $extraOptions[] = "-o StrictHostKeyChecking=no";
-            $extraOptions[] = "-o UserKnownHostsFile=/dev/null";
+            $extraOptions[] = '-o StrictHostKeyChecking=no';
+            $extraOptions[] = '-o UserKnownHostsFile=/dev/null';
         }
 
         return implode(' ', $extraOptions);

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -89,7 +89,10 @@ class Ssh
 
     protected function getExtraOptions(): string
     {
-        $extraOptions = [];
+        $extraOptions = [
+            "-o StrictHostKeyChecking=no",
+            " -o UserKnownHostsFile=/dev/null"
+        ];
 
         if ($this->pathToPrivateKey) {
             $extraOptions[] = "-i {$this->pathToPrivateKey}";

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -91,7 +91,7 @@ class Ssh
     {
         $extraOptions = [
             "-o StrictHostKeyChecking=no",
-            " -o UserKnownHostsFile=/dev/null"
+            "-o UserKnownHostsFile=/dev/null",
         ];
 
         if ($this->pathToPrivateKey) {

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -64,4 +64,12 @@ class SshTest extends TestCase
     {
         $this->assertInstanceOf(Ssh::class, Ssh::create('user', 'example.com'));
     }
+
+    /** @test */
+    public function it_can_enable_strict_host_checking()
+    {
+        $command = (new Ssh('user', 'example.com'))->enableStrictHostKeyChecking()->getSshCommand('woami');
+
+        $this->assertMatchesSnapshot($command);
+    }
 }

--- a/tests/__snapshots__/SshTest__it_can_enable_strict_host_checking__1.php
+++ b/tests/__snapshots__/SshTest__it_can_enable_strict_host_checking__1.php
@@ -1,0 +1,3 @@
+<?php return 'ssh  user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+woami
+EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_run_a_single_command__1.php
+++ b/tests/__snapshots__/SshTest__it_can_run_a_single_command__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh  user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_run_multiple_commands__1.php
+++ b/tests/__snapshots__/SshTest__it_can_run_multiple_commands__1.php
@@ -1,4 +1,4 @@
-<?php return 'ssh  user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 cd /var/log
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.php
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 123 user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -p 123 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.php
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -p 123 user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 123 user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.php
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 123 user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -p 123 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.php
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -p 123 user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 123 user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.php
+++ b/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/user/.ssh/id_rsa user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -i /home/user/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.php
+++ b/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -i /home/user/.ssh/id_rsa user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/user/.ssh/id_rsa user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';


### PR DESCRIPTION
This PR fixes #13 and adds a method to enable strict host key checking.