### PR TITLE
Use ssh-keyscan to add host to keyfile before usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Ssh::create('user', 'host')->usePrivateKey('/home/user/.ssh/id_rsa');
 
 ### Strict host key checking
 
-By default, strict host key checking is disabled. If you need more security you can enable strict host key checking using `enableStrictHostKeyChecking`.
+By default, strict host key checking is enabled. To disable use `disableStrictHostKeyChecking`
 
 ```php
-Ssh::create('user', 'host')->enableStrictHostKeyChecking();
+Ssh::create('user', 'host')->disableStrictHostKeyChecking();
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -92,7 +92,18 @@ Ssh::create('user', 'host')->usePrivateKey('/home/user/.ssh/id_rsa');
 
 ### Strict host key checking
 
-By default, strict host key checking is enabled. To disable use `disableStrictHostKeyChecking`
+By default, strict host key checking is enabled.
+
+The host key is obtained, prior to the SSH connection, by finding and running the `ssh-keyscan` utility.
+
+For more information about `ssh-keyscan`, use the `man` pages on your host system or see:
+* https://man.openbsd.org/ssh-keyscan (BSD verions)
+* https://linux.die.net/man/1/ssh-keyscan (GNU Linux versions)
+
+Warning: you will not be prompted to accept the key of the host system, it will automatically be accepted.
+You will thus lose the design feature of SSH where a new key indicates the host system has changed.
+
+To disable strict host key checking altogether, use `disableStrictHostKeyChecking`
 
 ```php
 Ssh::create('user', 'host')->disableStrictHostKeyChecking();

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -53,7 +53,7 @@ class Ssh
         return $this;
     }
 
-    public function useCustomKnownHostsFileLocation($path): self
+    public function useCustomKnownHostsFileLocation(string $path): self
     {
         $this->customKnownHostsFileLocation = $path;
 

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -16,6 +16,8 @@ class Ssh
 
     private bool $enableStrictHostChecking = true;
 
+    private ?string $customKnownHostsFileLocation = null;
+
     public function __construct(string $user, string $host, int $port = null)
     {
         $this->user = $user;
@@ -47,6 +49,13 @@ class Ssh
     public function disableStrictHostKeyChecking(): self
     {
         $this->enableStrictHostChecking = false;
+
+        return $this;
+    }
+
+    public function useCustomKnownHostsFileLocation($path): self
+    {
+        $this->customKnownHostsFileLocation = $path;
 
         return $this;
     }
@@ -113,7 +122,7 @@ class Ssh
             $extraOptions[] = '-o UserKnownHostsFile=/dev/null';
         } else {
             $extraOptions[] = '-o UserKnownHostsFile='.
-                (new SshKeyScan($this->host, $this->port))
+                (new SshKeyScan($this->host, $this->port, $this->customKnownHostsFileLocation))
                     ->getResultAsFilePath();
         }
 

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -68,9 +68,9 @@ class Ssh
 
         $target = "{$this->user}@{$this->host}";
 
-        return "ssh {$extraOptions} $target 'bash -se' << \\$delimiter" . PHP_EOL
-            . $commandString . PHP_EOL
-            . $delimiter;
+        return "ssh {$extraOptions} $target 'bash -se' << \\$delimiter".PHP_EOL
+            .$commandString.PHP_EOL
+            .$delimiter;
     }
 
     /**
@@ -93,7 +93,7 @@ class Ssh
 
     protected function wrapArray($arrayOrString): array
     {
-        return (array)$arrayOrString;
+        return (array) $arrayOrString;
     }
 
     protected function getExtraOptions(): string
@@ -108,7 +108,7 @@ class Ssh
             $extraOptions[] = "-p {$this->port}";
         }
 
-        if (!$this->enableStrictHostChecking) {
+        if (! $this->enableStrictHostChecking) {
             $extraOptions[] = '-o StrictHostKeyChecking=no';
             $extraOptions[] = '-o UserKnownHostsFile=/dev/null';
         } else {

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -112,7 +112,7 @@ class Ssh
             $extraOptions[] = '-o StrictHostKeyChecking=no';
             $extraOptions[] = '-o UserKnownHostsFile=/dev/null';
         } else {
-            $extraOptions[] = '-o UserKnownHostsFile=' .
+            $extraOptions[] = '-o UserKnownHostsFile='.
                 (new SshKeyScan($this->host, $this->port))
                     ->getResultAsFilePath();
         }

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -3,107 +3,88 @@
 namespace Spatie\Ssh;
 
 use InvalidArgumentException;
-use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 class SshKeyScan
 {
-    private string $sshPort = '22';
-
-    private string $keyType = 'rsa';
+    private string $path;
+    private string $result;
     /**
-     * @var string
-     */
-    private $path;
-    /**
-     * @var string
-     */
-    private $result;
-    /**
-     * @var resource
+     * @var null|resource
      */
     private $tmpFile;
-    /**
-     * @var string
-     */
-    private $tmpFilePath;
+    private string $tmpFilePath;
+    private string $filePath;
 
-    /**
-     * SshKeyScan constructor.
-     * @param string $hostAddress
-     * @param string $sshPort
-     * @param string $keyType
-     * @throws InvalidArgumentException
-     */
-    public function __construct(string $hostAddress, ?string $sshPort = '22', ?string $keyType = 'rsa')
+    public function __construct(string $hostAddress, ?string $sshPort = '22', ?string $filePath = null, ?string $keyType = 'rsa')
     {
-        if (! $this->systemHasCapability()) {
+        $this->filePath = $filePath;
+
+        if (!$this->ensureCanRunSshKeyscan()) {
             throw new InvalidArgumentException('Could not execute ssh-keyscan on host filesystem');
         }
 
-        $port = [];
-        if (null !== $sshPort) {
-            $port = ['-p', $sshPort];
-        }
+        $keyscan = new Process([
+            $this->path,
+            ...$this->getSshPort($sshPort),
+            '-H',
+            ...$this->getKeyType($keyType),
+            $hostAddress
+        ]);
 
-        $type = [];
-        if (null !== $keyType) {
-            $type = ['-t', $keyType];
-        }
+        $keyscan->run();
 
-        $keyscan = new Process([$this->path, ...$port, '-H', ...$type, $hostAddress]);
-        $keyscan->mustRun();
-
-        if ($keyscan->getExitCode() === 0) {
+        if ($keyscan->isSuccessful()) {
             $this->result = trim($keyscan->getOutput());
-            $this->writeContentsToTemporaryFile();
+            $this->writeContentsToTemporaryFile($filePath);
         } else {
             throw new InvalidArgumentException('Could not obtain host keys with ssh-keyscan');
         }
     }
 
-    private function writeContentsToTemporaryFile(): void
-    {
-        $this->tmpFile = tmpfile();
-        $this->tmpFilePath = stream_get_meta_data($this->tmpFile)['uri'];
-        file_put_contents($this->tmpFilePath, $this->result);
-    }
-
-    /**
-     * @return string
-     */
-    public function getResultAsString(): string
-    {
-        return $this->result;
-    }
-
-    /**
-     * @return string
-     */
-    public function getResultAsFilePath(): string
-    {
-        return $this->tmpFilePath;
-    }
-
-    /**
-     * @return bool
-     */
-    public function systemHasCapability(): bool
+    public function ensureCanRunSshKeyscan(): bool
     {
         $which = new Process(['which', 'ssh-keyscan']);
 
-        try {
-            $which->mustRun();
-        } catch (ProcessFailedException $exception) {
-            return false;
+        $which->run();
+
+        if ($which->isSuccessful()) {
+            $this->path = trim($which->getOutput());
+            return true;
         }
 
-        if ($which->getExitCode() !== 0) {
-            return false;
+        return false;
+    }
+
+    protected function getSshPort(?string $sshPort, array $port = []): array
+    {
+        if (null !== $sshPort) {
+            $port = ['-p', $sshPort];
         }
+        return $port;
+    }
 
-        $this->path = trim($which->getOutput());
+    protected function getKeyType(?string $keyType, array $type = []): array
+    {
+        if (null !== $keyType) {
+            $type = ['-t', $keyType];
+        }
+        return $type;
+    }
 
-        return true;
+    protected function writeContentsToTemporaryFile(?string $customPath): void
+    {
+        if (null !== $customPath) {
+            file_put_contents($customPath, $this->result);
+        } else {
+            $this->tmpFile = tmpfile();
+            $this->tmpFilePath = stream_get_meta_data($this->tmpFile)['uri'];
+            file_put_contents($this->tmpFilePath, $this->result);
+        }
+    }
+
+    public function getResultAsFilePath(): string
+    {
+        return $this->filePath ?? $this->tmpFilePath;
     }
 }

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Spatie\Ssh;
+
+use InvalidArgumentException;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Class SshKeyScan
+ * @package Spatie\Ssh
+ */
+class SshKeyScan
+{
+    /**
+     * @var string
+     */
+    private string $path;
+    /**
+     * @var string
+     */
+    private $result;
+    /**
+     * @var resource
+     */
+    private $tmpFile;
+    /**
+     * @var string
+     */
+    private string $tmpFilePath;
+
+    /**
+     * SshKeyScan constructor.
+     * @param string $hostAddress
+     * @param string $sshPort
+     * @param string $keyType
+     * @throws InvalidArgumentException
+     */
+    public function __construct(string $hostAddress, $sshPort = '22', $keyType = 'rsa')
+    {
+        if (!$this->systemHasCapability()) {
+            throw new InvalidArgumentException('Could not execute ssh-keyscan on host filesystem');
+        }
+
+        $keyscan = new Process([$this->path, '-p', (string)$sshPort, '-H', '-t', $keyType, $hostAddress]);
+        $keyscan->mustRun();
+
+        if ($keyscan->getExitCode() !== 0) {
+            $this->result = trim($keyscan->getOutput());
+            $this->writeContentsToTemporaryFile();
+        }
+    }
+
+    private function writeContentsToTemporaryFile(): void
+    {
+        $this->tmpFile = tmpfile();
+        $this->tmpFilePath = stream_get_meta_data($this->tmpFile)['uri'];
+        file_put_contents($this->tmpFilePath, $this->result);
+    }
+
+    /**
+     * @return string
+     */
+    public function getResultAsString(): string
+    {
+        return $this->result;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResultAsFilePath(): string
+    {
+        return $this->tmpFilePath;
+    }
+
+    /**
+     * @return bool
+     */
+    public function systemHasCapability(): bool
+    {
+        $which = new Process(['which', 'ssh-keyscan']);
+
+        try {
+            $which->mustRun();
+        } catch (ProcessFailedException $exception) {
+            return false;
+        }
+
+        if ($which->getExitCode() !== 0) {
+            return false;
+        }
+
+        $this->path = trim($which->getOutput());
+        return true;
+    }
+}

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -9,12 +9,8 @@ class SshKeyScan
 {
     private string $path;
     private string $result;
-    /**
-     * @var null|resource
-     */
-    private $tmpFile;
     private string $tmpFilePath;
-    private string $filePath;
+    private ?string $filePath;
 
     public function __construct(string $hostAddress, ?string $sshPort = '22', ?string $filePath = null, ?string $keyType = 'rsa')
     {
@@ -80,8 +76,7 @@ class SshKeyScan
         if (null !== $customPath) {
             file_put_contents($customPath, $this->result);
         } else {
-            $this->tmpFile = tmpfile();
-            $this->tmpFilePath = stream_get_meta_data($this->tmpFile)['uri'];
+            $this->tmpFilePath = stream_get_meta_data(tmpfile())['uri'];
             file_put_contents($this->tmpFilePath, $this->result);
         }
     }

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -6,10 +6,6 @@ use InvalidArgumentException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-/**
- * Class SshKeyScan
- * @package Spatie\Ssh
- */
 class SshKeyScan
 {
     private string $sshPort = '22';
@@ -41,7 +37,7 @@ class SshKeyScan
      */
     public function __construct(string $hostAddress, ?string $sshPort = '22', ?string $keyType = 'rsa')
     {
-        if (!$this->systemHasCapability()) {
+        if (! $this->systemHasCapability()) {
             throw new InvalidArgumentException('Could not execute ssh-keyscan on host filesystem');
         }
 
@@ -107,6 +103,7 @@ class SshKeyScan
         }
 
         $this->path = trim($which->getOutput());
+
         return true;
     }
 }

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -20,7 +20,7 @@ class SshKeyScan
     {
         $this->filePath = $filePath;
 
-        if (!$this->ensureCanRunSshKeyscan()) {
+        if (! $this->ensureCanRunSshKeyscan()) {
             throw new InvalidArgumentException('Could not execute ssh-keyscan on host filesystem');
         }
 
@@ -29,7 +29,7 @@ class SshKeyScan
             ...$this->getSshPort($sshPort),
             '-H',
             ...$this->getKeyType($keyType),
-            $hostAddress
+            $hostAddress,
         ]);
 
         $keyscan->run();
@@ -50,6 +50,7 @@ class SshKeyScan
 
         if ($which->isSuccessful()) {
             $this->path = trim($which->getOutput());
+
             return true;
         }
 
@@ -61,6 +62,7 @@ class SshKeyScan
         if (null !== $sshPort) {
             $port = ['-p', $sshPort];
         }
+
         return $port;
     }
 
@@ -69,6 +71,7 @@ class SshKeyScan
         if (null !== $keyType) {
             $type = ['-t', $keyType];
         }
+
         return $type;
     }
 

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -15,7 +15,7 @@ class SshKeyScan
     /**
      * @var string
      */
-    private string $path;
+    private $path;
     /**
      * @var string
      */
@@ -27,7 +27,7 @@ class SshKeyScan
     /**
      * @var string
      */
-    private string $tmpFilePath;
+    private $tmpFilePath;
 
     /**
      * SshKeyScan constructor.

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -66,9 +66,9 @@ class SshTest extends TestCase
     }
 
     /** @test */
-    public function it_can_enable_strict_host_checking()
+    public function it_can_disable_strict_host_checking()
     {
-        $command = (new Ssh('user', 'example.com'))->enableStrictHostKeyChecking()->getSshCommand('woami');
+        $command = (new Ssh('user', 'example.com'))->disableStrictHostKeyChecking()->getSshCommand('woami');
 
         $this->assertMatchesSnapshot($command);
     }

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -22,7 +22,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_run_a_single_command()
     {
-        $command = $this->ssh->getSshCommand('whoami');
+        $command = $this->ssh->useCustomKnownHostsFileLocation('/tmp/test')->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }
@@ -30,7 +30,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_run_multiple_commands()
     {
-        $command = $this->ssh->getSshCommand(['whoami', 'cd /var/log']);
+        $command = $this->ssh->useCustomKnownHostsFileLocation('/tmp/test')->getSshCommand(['whoami', 'cd /var/log']);
 
         $this->assertMatchesSnapshot($command);
     }
@@ -38,7 +38,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_use_a_specific_private_key()
     {
-        $command = $this->ssh->usePrivateKey('/home/user/.ssh/id_rsa')->getSshCommand('whoami');
+        $command = $this->ssh->useCustomKnownHostsFileLocation('/tmp/test')->usePrivateKey('/home/user/.ssh/id_rsa')->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }
@@ -46,7 +46,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_set_the_port_via_the_constructor()
     {
-        $command = (new Ssh('user', 'example.com', 123))->getSshCommand('whoami');
+        $command = (new Ssh('user', 'example.com', 123))->useCustomKnownHostsFileLocation('/tmp/test')->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }
@@ -54,7 +54,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_set_the_port_via_the_dedicated_function()
     {
-        $command = (new Ssh('user', 'example.com'))->usePort(123)->getSshCommand('whoami');
+        $command = (new Ssh('user', 'example.com'))->useCustomKnownHostsFileLocation('/tmp/test')->usePort(123)->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }

--- a/tests/__snapshots__/SshTest__it_can_disable_strict_host_checking__1.php
+++ b/tests/__snapshots__/SshTest__it_can_disable_strict_host_checking__1.php
@@ -1,0 +1,3 @@
+<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+woami
+EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_enable_strict_host_checking__1.php
+++ b/tests/__snapshots__/SshTest__it_can_enable_strict_host_checking__1.php
@@ -1,3 +1,0 @@
-<?php return 'ssh  user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
-woami
-EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_run_a_single_command__1.php
+++ b/tests/__snapshots__/SshTest__it_can_run_a_single_command__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_run_multiple_commands__1.php
+++ b/tests/__snapshots__/SshTest__it_can_run_multiple_commands__1.php
@@ -1,4 +1,4 @@
-<?php return 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 cd /var/log
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.php
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -p 123 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -p 123 -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.php
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -p 123 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -p 123 -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.php
+++ b/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -i /home/user/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -i /home/user/.ssh/id_rsa -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';


### PR DESCRIPTION
In reference to #13, a proposal to fix the issue at hand by running ssh-keyscan on the host, taking the key (hashed for security) and putting it in a temporary file, then serving it to the SSH command.