### PR TITLE
ssh-keyscan & known_hosts file 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.4",
-        "symfony/process": "^4.3 || ^5.0"
+        "symfony/process": "^4.3 || ^5.0",
+        "ext-posix": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.2",

--- a/src/KnownHosts.php
+++ b/src/KnownHosts.php
@@ -22,11 +22,11 @@ class KnownHosts
 
     public function __construct(?string $customKnownHostsFile)
     {
-        if(! $this->hasPosixExtension()) {
+        if (! $this->hasPosixExtension()) {
             throw new RuntimeException('PHP does not have POSIX extension enabled');
         }
 
-        if(! $this->hasEnvHomeSet()) {
+        if (! $this->hasEnvHomeSet()) {
             throw new RuntimeException('PHP cannot find $HOME env setting');
         }
 

--- a/src/KnownHosts.php
+++ b/src/KnownHosts.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Spatie\Ssh;
+
+use RuntimeException;
+
+/**
+ * Manages the creation of known_hosts and accepts new entries
+ * A custom file path can be provided
+ *
+ * Assumes:
+ *  - Host system is POSIX compliant
+ *  - the $HOME variable is set
+ *  - PHP user is allowed to make changes to known_hosts file and path
+ */
+class KnownHosts
+{
+    protected string $knownHostsDirectory = '.ssh';
+
+    protected string $knownHostsFile = 'known_hosts';
+
+    protected int $directoryMode = 0700;
+
+    protected int $fileMode = 0644;
+
+    protected string $path;
+
+    protected string $user;
+
+    protected string $file;
+
+    public function __construct(?string $customKnownHostsFile)
+    {
+        $this->user = $this->getUser();
+        if (null !== $customKnownHostsFile) {
+            $this->path = dirname($customKnownHostsFile);
+            $this->file = $customKnownHostsFile;
+        } else {
+            $this->path = $this->getPath();
+            $this->file = $this->getFile();
+        }
+    }
+
+    public function addHost(string $hostHash): void
+    {
+        $fileContents = file($this->file, FILE_SKIP_EMPTY_LINES);
+        $fileContents[] = $hostHash . PHP_EOL;
+        file_put_contents($this->file, implode(PHP_EOL, array_unique($fileContents)));
+    }
+
+    protected function getFile(): string
+    {
+        return $this->ensureSshKnownHostsFileExists();
+    }
+
+    protected function ensureSshDirectoryExists(): void
+    {
+        if (!is_dir($this->path) && !mkdir($this->path, $this->directoryMode, true) && !is_dir($this->path)) {
+            throw new RuntimeException('Directory "' . $this->path . '" was not created');
+        }
+        self::chownIfRequired($this->path, $this->user);
+    }
+
+    protected function ensureSshKnownHostsFileExists(): string
+    {
+        $this->ensureSshDirectoryExists();
+        $filePath = $this->path . DIRECTORY_SEPARATOR . $this->knownHostsFile;
+        self::touchIfRequired($filePath);
+        self::chownIfRequired($filePath, $this->user);
+        self::chmodIfRequired($filePath, $this->fileMode);
+
+        return $filePath;
+    }
+
+    protected function getUser(): string
+    {
+        return get_current_user();
+    }
+
+    protected function getPath(): string
+    {
+        return realpath(getenv('HOME') . DIRECTORY_SEPARATOR . $this->knownHostsDirectory);
+    }
+
+    /**
+     * To find out which username belongs to UID, ext-posix is required.
+     * https://www.php.net/manual/en/function.posix-getpwuid.php
+     */
+    protected static function getUsernameByUid(int $uid): string
+    {
+        return posix_getpwuid($uid)['name'];
+    }
+
+    protected static function chownIfRequired(string $path, string $user): void
+    {
+        if ($user !== self::getUsernameByUid(fileowner($path))) {
+            chown($path, $user);
+        }
+    }
+
+    protected static function chmodIfRequired(string $path, int $mode): void
+    {
+        if ($mode !== self::getOctalPermissions($path)) {
+            chmod($path, $mode);
+        }
+    }
+
+    protected static function touchIfRequired(string $path): void
+    {
+        if (!file_exists($path)) {
+            touch($path);
+        }
+    }
+
+    /**
+     * Output of fileperms is not octal, but it can be filtered out:
+     * https://www.php.net/manual/en/function.fileperms.php
+     */
+    protected static function getOctalPermissions(string $path): int
+    {
+        return (int)substr(sprintf('%o', fileperms($path)), -4);
+    }
+}

--- a/src/KnownHosts.php
+++ b/src/KnownHosts.php
@@ -22,13 +22,11 @@ class KnownHosts
 
     public function __construct(?string $customKnownHostsFile)
     {
-        if(! $this->hasPosixExtension())
-        {
+        if(! $this->hasPosixExtension()) {
             throw new RuntimeException('PHP does not have POSIX extension enabled');
         }
 
-        if(! $this->hasEnvHomeSet())
-        {
+        if(! $this->hasEnvHomeSet()) {
             throw new RuntimeException('PHP cannot find $HOME env setting');
         }
 

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -121,8 +121,7 @@ class Ssh
             (new SshKeyScan())
                 ->do($this->host, $this->port, $this->customKnownHostsFileLocation);
 
-            if(null !== $this->customKnownHostsFileLocation)
-            {
+            if(null !== $this->customKnownHostsFileLocation) {
                 $extraOptions[] = "-o UserKnownHostsFile={$this->customKnownHostsFileLocation}";
             }
         } else {

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -118,10 +118,13 @@ class Ssh
         }
 
         if ($this->enableStrictHostChecking) {
-            $knownHostsFilePath = (new SshKeyScan())->getKnownHostFilePath($this->host, $this->port, $this->customKnownHostsFileLocation, 'rsa');
+            (new SshKeyScan())
+                ->do($this->host, $this->port, $this->customKnownHostsFileLocation);
 
-            $extraOptions[] = "-o UserKnownHostsFile={$knownHostsFilePath}";
-
+            if(null !== $this->customKnownHostsFileLocation)
+            {
+                $extraOptions[] = "-o UserKnownHostsFile={$this->customKnownHostsFileLocation}";
+            }
         } else {
             $extraOptions[] = '-o StrictHostKeyChecking=no';
             $extraOptions[] = '-o UserKnownHostsFile=/dev/null';

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -121,7 +121,7 @@ class Ssh
             (new SshKeyScan())
                 ->do($this->host, $this->port, $this->customKnownHostsFileLocation);
 
-            if(null !== $this->customKnownHostsFileLocation) {
+            if (null !== $this->customKnownHostsFileLocation) {
                 $extraOptions[] = "-o UserKnownHostsFile={$this->customKnownHostsFileLocation}";
             }
         } else {

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -5,35 +5,41 @@ namespace Spatie\Ssh;
 use InvalidArgumentException;
 use Symfony\Component\Process\Process;
 
+/**
+ * Obtains SSH key from remote system
+ * Assumes:
+ *  - Host system is POSIX compliant
+ *  - Has ssh-keyscan (part of openssh-client toolchain) installed
+ */
 class SshKeyScan
 {
-    public function getKnownHostFilePath(string $hostAddress, ?string $sshPort, ?string $filePath, string $keyType = 'rsa'): string
+    public function do(string $hostAddress, ?int $sshPort = 22, ?string $filePath = null, string $keyType = 'rsa'): void
     {
-        $filePath = $filePath ?? stream_get_meta_data(tmpfile())['uri'];
-
         $process = new Process([
             $this->getSshKeyscanPath(),
-            ...$this->getSshPort($sshPort),
-            '-H',
-            '-t',
-            $keyType,
-            $hostAddress,
+            ...$this->getSshPort((string)$sshPort),
+            '-t', $keyType,
+            $this->getFormattedHostAddress($hostAddress),
         ]);
 
         $process->run();
 
         if (!$process->isSuccessful()) {
+            var_dump($process);
             throw new InvalidArgumentException('Could not obtain host keys with ssh-keyscan');
         }
 
-        $result = trim($process->getOutput());
+//        if ('' === $process->getOutput()) {
+//            throw new InvalidArgumentException(sprintf('Could not obtain host key from %s:%s', $hostAddress, $sshPort));
+//        }
 
-        file_put_contents($filePath, $result);
-
-        return $filePath;
+        (new KnownHosts($filePath))
+            ->addHost(
+                trim($process->getOutput())
+            );
     }
 
-    public function getSshKeyscanPath(): string
+    protected function getSshKeyscanPath(): string
     {
         $process = new Process(['which', 'ssh-keyscan']);
 
@@ -46,9 +52,22 @@ class SshKeyScan
         return trim($process->getOutput());
     }
 
+    /**
+     * Returns: Hostname,IP address
+     * This is to ensure connections to both hostname address and ip address succeed.
+     */
+    protected function getFormattedHostAddress(string $hostAddress): string
+    {
+        if (filter_var($hostAddress, FILTER_VALIDATE_IP)) {
+            return gethostbyaddr($hostAddress) . ',' . $hostAddress;
+        }
+
+        return $hostAddress . ',' . gethostbyname($hostAddress);
+    }
+
     protected function getSshPort(?string $sshPort): array
     {
-        return is_null($sshPort)
+        return null !== $sshPort
             ? []
             : ['-p', $sshPort];
     }

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -19,7 +19,7 @@ class SshKeyScan
         $process->run();
 
         if (! $process->isSuccessful()) {
-            throw new InvalidArgumentException('Could not obtain host keys with ssh-keyscan: ' . $process->getOutput());
+            throw new InvalidArgumentException('Could not obtain host keys with ssh-keyscan: '.$process->getOutput());
         }
 
         if ('' !== $process->getOutput()) {

--- a/src/SshKeyScan.php
+++ b/src/SshKeyScan.php
@@ -5,38 +5,29 @@ namespace Spatie\Ssh;
 use InvalidArgumentException;
 use Symfony\Component\Process\Process;
 
-/**
- * Obtains SSH key from remote system
- * Assumes:
- *  - Host system is POSIX compliant
- *  - Has ssh-keyscan (part of openssh-client toolchain) installed
- */
 class SshKeyScan
 {
     public function do(string $hostAddress, ?int $sshPort = 22, ?string $filePath = null, string $keyType = 'rsa'): void
     {
         $process = new Process([
             $this->getSshKeyscanPath(),
-            ...$this->getSshPort((string)$sshPort),
+            ...$this->getSshPort((string) $sshPort),
             '-t', $keyType,
             $this->getFormattedHostAddress($hostAddress),
         ]);
 
         $process->run();
 
-        if (!$process->isSuccessful()) {
-            var_dump($process);
-            throw new InvalidArgumentException('Could not obtain host keys with ssh-keyscan');
+        if (! $process->isSuccessful()) {
+            throw new InvalidArgumentException('Could not obtain host keys with ssh-keyscan: ' . $process->getOutput());
         }
 
-//        if ('' === $process->getOutput()) {
-//            throw new InvalidArgumentException(sprintf('Could not obtain host key from %s:%s', $hostAddress, $sshPort));
-//        }
-
-        (new KnownHosts($filePath))
-            ->addHost(
-                trim($process->getOutput())
-            );
+        if ('' !== $process->getOutput()) {
+            (new KnownHosts($filePath))
+                ->addHost(
+                    trim($process->getOutput())
+                );
+        }
     }
 
     protected function getSshKeyscanPath(): string
@@ -45,7 +36,7 @@ class SshKeyScan
 
         $process->run();
 
-        if (!$process->isSuccessful()) {
+        if (! $process->isSuccessful()) {
             throw new InvalidArgumentException('Could not execute ssh-keyscan on host filesystem');
         }
 
@@ -59,10 +50,10 @@ class SshKeyScan
     protected function getFormattedHostAddress(string $hostAddress): string
     {
         if (filter_var($hostAddress, FILTER_VALIDATE_IP)) {
-            return gethostbyaddr($hostAddress) . ',' . $hostAddress;
+            return gethostbyaddr($hostAddress).','.$hostAddress;
         }
 
-        return $hostAddress . ',' . gethostbyname($hostAddress);
+        return $hostAddress.','.gethostbyname($hostAddress);
     }
 
     protected function getSshPort(?string $sshPort): array

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -16,13 +16,23 @@ class SshTest extends TestCase
     {
         parent::setUp();
 
-        $this->ssh = (new Ssh('user', 'example.com'));
+        touch('/tmp/custom');
+        touch('/tmp/test');
+        $this->ssh = (new Ssh('user', 'github.com'));
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        unlink('/tmp/custom');
+        unlink('/tmp/test');
     }
 
     /** @test */
     public function it_can_run_a_single_command()
     {
-        $command = $this->ssh->useCustomKnownHostsFileLocation('/tmp/test')->getSshCommand('whoami');
+        $command = $this->ssh->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }
@@ -30,7 +40,15 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_run_multiple_commands()
     {
-        $command = $this->ssh->useCustomKnownHostsFileLocation('/tmp/test')->getSshCommand(['whoami', 'cd /var/log']);
+        $command = $this->ssh->getSshCommand(['whoami', 'cd /var/log']);
+
+        $this->assertMatchesSnapshot($command);
+    }
+
+    /** @test */
+    public function it_can_use_a_custom_known_hosts_file_location()
+    {
+        $command = $this->ssh->useCustomKnownHostsFileLocation('/tmp/custom')->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }
@@ -38,7 +56,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_use_a_specific_private_key()
     {
-        $command = $this->ssh->useCustomKnownHostsFileLocation('/tmp/test')->usePrivateKey('/home/user/.ssh/id_rsa')->getSshCommand('whoami');
+        $command = $this->ssh->usePrivateKey('/home/user/.ssh/id_rsa')->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }
@@ -46,7 +64,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_set_the_port_via_the_constructor()
     {
-        $command = (new Ssh('user', 'example.com', 123))->useCustomKnownHostsFileLocation('/tmp/test')->getSshCommand('whoami');
+        $command = (new Ssh('user', 'example.com', 123))->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }
@@ -54,7 +72,7 @@ class SshTest extends TestCase
     /** @test */
     public function it_can_set_the_port_via_the_dedicated_function()
     {
-        $command = (new Ssh('user', 'example.com'))->useCustomKnownHostsFileLocation('/tmp/test')->usePort(123)->getSshCommand('whoami');
+        $command = (new Ssh('user', 'example.com'))->usePort(123)->getSshCommand('whoami');
 
         $this->assertMatchesSnapshot($command);
     }

--- a/tests/__snapshots__/SshTest__it_can_run_a_single_command__1.php
+++ b/tests/__snapshots__/SshTest__it_can_run_a_single_command__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh  user@github.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_run_multiple_commands__1.php
+++ b/tests/__snapshots__/SshTest__it_can_run_multiple_commands__1.php
@@ -1,4 +1,4 @@
-<?php return 'ssh -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh  user@github.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 cd /var/log
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.php
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -p 123 -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -p 123 user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.php
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -p 123 -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -p 123 user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_use_a_custom_known_hosts_file_location__1.php
+++ b/tests/__snapshots__/SshTest__it_can_use_a_custom_known_hosts_file_location__1.php
@@ -1,0 +1,3 @@
+<?php return 'ssh -o UserKnownHostsFile=/tmp/custom user@github.com \'bash -se\' << \\EOF-SPATIE-SSH
+whoami
+EOF-SPATIE-SSH';

--- a/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.php
+++ b/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.php
@@ -1,3 +1,3 @@
-<?php return 'ssh -i /home/user/.ssh/id_rsa -o UserKnownHostsFile=/tmp/test user@example.com \'bash -se\' << \\EOF-SPATIE-SSH
+<?php return 'ssh -i /home/user/.ssh/id_rsa user@github.com \'bash -se\' << \\EOF-SPATIE-SSH
 whoami
 EOF-SPATIE-SSH';


### PR DESCRIPTION
In reference to #17.

Ended up creating the KnownHosts class to manage file existence and allow new host entries to be made. It will accept a custom location if the regular `~/.ssh/known_hosts` is not an option (distributed systems).

Tried to stay away from further library dependencies, but this code is tied to the posix extension, which is enabled by default by PHP (https://www.php.net/manual/en/posix.installation.php).

The code is a bit rough, and I suppose not completely up to your style, but please let me know if and how you want this code adjusted.