### PR TITLE
Fix port validation check

### DIFF
--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -111,7 +111,7 @@ class Ssh
             $extraOptions[] = "-i {$this->pathToPrivateKey}";
         }
 
-        if ($this->port > -1) {
+        if ($this->port >= 0) {
             $extraOptions[] = "-p {$this->port}";
         }
 

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -75,7 +75,7 @@ class Ssh
 
         $target = "{$this->user}@{$this->host}";
 
-        return "ssh {$extraOptions} $target 'bash -se' << \\$delimiter" . PHP_EOL
+        return "ssh {$extraOptions} $target 'bash -se' << \\$delimiter".PHP_EOL
             .$commandString.PHP_EOL
             .$delimiter;
     }

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -76,8 +76,8 @@ class Ssh
         $target = "{$this->user}@{$this->host}";
 
         return "ssh {$extraOptions} $target 'bash -se' << \\$delimiter" . PHP_EOL
-            . $commandString . PHP_EOL
-            . $delimiter;
+            .$commandString.PHP_EOL
+            .$delimiter;
     }
 
     /**
@@ -115,7 +115,7 @@ class Ssh
             $extraOptions[] = "-p {$this->port}";
         }
 
-        if (!$this->enableStrictHostChecking) {
+        if (! $this->enableStrictHostChecking) {
             $extraOptions[] = '-o StrictHostKeyChecking=no';
             $extraOptions[] = '-o UserKnownHostsFile=/dev/null';
         }

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -75,9 +75,9 @@ class Ssh
 
         $target = "{$this->user}@{$this->host}";
 
-        return "ssh {$extraOptions} $target 'bash -se' << \\$delimiter".PHP_EOL
-            .$commandString.PHP_EOL
-            .$delimiter;
+        return "ssh {$extraOptions} $target 'bash -se' << \\$delimiter" . PHP_EOL
+            . $commandString . PHP_EOL
+            . $delimiter;
     }
 
     /**
@@ -111,11 +111,11 @@ class Ssh
             $extraOptions[] = "-i {$this->pathToPrivateKey}";
         }
 
-        if ($this->port) {
+        if ($this->port > -1) {
             $extraOptions[] = "-p {$this->port}";
         }
 
-        if (! $this->enableStrictHostChecking) {
+        if (!$this->enableStrictHostChecking) {
             $extraOptions[] = '-o StrictHostKeyChecking=no';
             $extraOptions[] = '-o UserKnownHostsFile=/dev/null';
         }

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -52,6 +52,13 @@ class SshTest extends TestCase
     }
 
     /** @test */
+    public function it_can_evaluate_port()
+    {
+        $command = (new Ssh('user', 'example.com', 0))->getSshCommand('whoami');
+        $this->assertMatchesSnapshot($command);
+    }
+
+    /** @test */
     public function it_can_set_the_port_via_the_dedicated_function()
     {
         $command = (new Ssh('user', 'example.com'))->usePort(123)->getSshCommand('whoami');

--- a/tests/__snapshots__/SshTest__it_can_evaluate_port__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_evaluate_port__1.txt
@@ -1,0 +1,3 @@
+ssh -p 0 user@example.com 'bash -se' << \EOF-SPATIE-SSH
+whoami
+EOF-SPATIE-SSH


### PR DESCRIPTION
Change validation check logic to prevent a port number of `0` being evaluated as false.