### PR TITLE
Add ability to disable/enable password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ By default, the quiet mode is disabled. You can enable quiet mode using `enableQ
 Ssh::create('user', 'host')->enableQuietMode();
 ```
 
+### Disable Password Authentication
+
+By default, the password authentication is enabled. You can disable password authentication using `disablePasswordAuthentication`.
+
+```php
+Ssh::create('user', 'host')->disablePasswordAuthentication();
+```
+
 ### Uploading & downloading files and directories
 
 You can upload files & directories to a host using:

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -20,6 +20,8 @@ class Ssh
 
     protected bool $quietMode = false;
 
+    protected bool $enablePasswordAuthentication = true;
+
     protected Closure $processConfigurationClosure;
 
     protected Closure $onOutput;
@@ -99,6 +101,18 @@ class Ssh
         $this->quietMode = false;
 
         return $this;
+    }
+
+    public function disablePasswordAuthentication(): self
+    {
+        $this->enablePasswordAuthentication = false;
+
+        return $this;
+    }
+
+    public function enablePasswordAuthentication(): self
+    {
+        $this->enablePasswordAuthentication = true;
     }
 
     /**
@@ -206,6 +220,10 @@ class Ssh
         if (! $this->enableStrictHostChecking) {
             $extraOptions[] = '-o StrictHostKeyChecking=no';
             $extraOptions[] = '-o UserKnownHostsFile=/dev/null';
+        }
+
+        if (! $this->enablePasswordAuthentication) {
+            $extraOptions[] = '-o PasswordAuthentication=no';
         }
 
         if ($this->quietMode) {

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -113,6 +113,8 @@ class Ssh
     public function enablePasswordAuthentication(): self
     {
         $this->enablePasswordAuthentication = true;
+
+        return $this;
     }
 
     /**

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -92,6 +92,14 @@ class SshTest extends TestCase
     }
 
     /** @test */
+    public function it_can_enable_password_authentication()
+    {
+        $command = (new Ssh('user', 'example.com'))->enablePasswordAuthentication()->getExecuteCommand('whoami');
+
+        $this->assertMatchesSnapshot($command);
+    }
+
+    /** @test */
     public function zero_is_a_valid_port_number()
     {
         $command = (new Ssh('user', 'example.com'))->usePort(0)->getExecuteCommand('whoami');

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -84,6 +84,14 @@ class SshTest extends TestCase
     }
 
     /** @test */
+    public function it_can_disable_password_authentication()
+    {
+        $command = (new Ssh('user', 'example.com'))->disablePasswordAuthentication()->getExecuteCommand('whoami');
+
+        $this->assertMatchesSnapshot($command);
+    }
+
+    /** @test */
     public function zero_is_a_valid_port_number()
     {
         $command = (new Ssh('user', 'example.com'))->usePort(0)->getExecuteCommand('whoami');

--- a/tests/__snapshots__/SshTest__it_can_disable_password_authentication__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_disable_password_authentication__1.txt
@@ -1,0 +1,3 @@
+ssh -o PasswordAuthentication=no user@example.com 'bash -se' << \EOF-SPATIE-SSH
+whoami
+EOF-SPATIE-SSH

--- a/tests/__snapshots__/SshTest__it_can_enable_password_authentication__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_enable_password_authentication__1.txt
@@ -1,0 +1,3 @@
+ssh  user@example.com 'bash -se' << \EOF-SPATIE-SSH
+whoami
+EOF-SPATIE-SSH


### PR DESCRIPTION
Found out that using wrong/incorrect private key shows prompt to enter password. With this flag it should eliminate this problem.