### PR TITLE
Support for 'Identities Only'

### DIFF
--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -18,6 +18,8 @@ class Ssh
 
     protected bool $enableStrictHostChecking = true;
 
+    protected bool $identitiesOnly = false;
+
     protected bool $quietMode = false;
 
     protected bool $enablePasswordAuthentication = true;
@@ -99,6 +101,20 @@ class Ssh
     public function disableQuietMode(): self
     {
         $this->quietMode = false;
+
+        return $this;
+    }
+
+    public function enableIdentitiesOnly(): self
+    {
+        $this->identitiesOnly = true;
+
+        return $this;
+    }
+
+    public function disableIdentitiesOnly(): self
+    {
+        $this->identitiesOnly = false;
 
         return $this;
     }
@@ -226,6 +242,10 @@ class Ssh
 
         if (! $this->enablePasswordAuthentication) {
             $extraOptions[] = '-o PasswordAuthentication=no';
+        }
+
+        if ($this->identitiesOnly) {
+            $extraOptions[] = '-o IdentitiesOnly=yes';
         }
 
         if ($this->quietMode) {

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -84,6 +84,14 @@ class SshTest extends TestCase
     }
 
     /** @test */
+    public function it_can_enable_identities_only()
+    {
+        $command = (new Ssh('user', 'example.com'))->enableIdentitiesOnly()->getExecuteCommand('whoami');
+
+        $this->assertMatchesSnapshot($command);
+    }
+
+    /** @test */
     public function it_can_disable_password_authentication()
     {
         $command = (new Ssh('user', 'example.com'))->disablePasswordAuthentication()->getExecuteCommand('whoami');

--- a/tests/__snapshots__/SshTest__it_can_enable_identities_only__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_enable_identities_only__1.txt
@@ -1,0 +1,3 @@
+ssh -o IdentitiesOnly=yes user@example.com 'bash -se' << \EOF-SPATIE-SSH
+whoami
+EOF-SPATIE-SSH


### PR DESCRIPTION
Useful when using a specific private key, to prevent offering other keys.