### PR TITLE
uppercase port option for scp

### DIFF
--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -197,11 +197,15 @@ class Ssh
 
     protected function getExtraScpOptions(): string
     {
-        $extraOptions = $this->getExtraOptions();
+        $extraOptions = $this->extraOptions;
+
+        if (isset($extraOptions['port'])) {
+            $extraOptions['port'] = str_replace('-p', '-P', $extraOptions['port']);
+        }
 
         $extraOptions[] = '-r';
 
-        return implode(' ', $extraOptions);
+        return implode(' ', array_values($extraOptions));
     }
 
     private function getExtraOptions(): array


### PR DESCRIPTION
It appears in the refactor into extra options in `1.7.0` that this line was removed:

https://github.com/spatie/ssh/compare/1.6.0...1.7.0#diff-5d960cb119d12ad8d1d5a0e2075f46ea699e824926b237972eedae4a8a0ac9a6L208

The SCP option is an uppercase `-P`, but with the refactor, this is now imploding the `-p`

This is resulting in a failure to run any upload command using `scp` (even when using port 22)