### PR TITLE
Change SSH command for Windows compatibility

### DIFF
--- a/tests/__snapshots__/SshTest__it_can_configure_the_used_process__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_configure_the_used_process__1.txt
@@ -1,3 +1,1 @@
-ssh  user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_disable_password_authentication__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_disable_password_authentication__1.txt
@@ -1,3 +1,1 @@
-ssh -o PasswordAuthentication=no user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh -o PasswordAuthentication=no user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_enable_password_authentication__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_enable_password_authentication__1.txt
@@ -1,3 +1,1 @@
-ssh  user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_enable_quiet_mode__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_enable_quiet_mode__1.txt
@@ -1,3 +1,1 @@
-ssh -q user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh -q user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_enable_strict_host_checking__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_enable_strict_host_checking__1.txt
@@ -1,3 +1,1 @@
-ssh  user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_run_a_single_command__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_run_a_single_command__1.txt
@@ -1,3 +1,1 @@
-ssh  user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_run_multiple_commands__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_run_multiple_commands__1.txt
@@ -1,4 +1,1 @@
-ssh  user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-cd /var/log
-EOF-SPATIE-SSH
+ssh user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_constructor__1.txt
@@ -1,3 +1,1 @@
-ssh -p 123 user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh -p 123 user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_set_the_port_via_the_dedicated_function__1.txt
@@ -1,3 +1,1 @@
-ssh -p 123 user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh -p 123 user@example.com bash

--- a/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_use_a_specific_private_key__1.txt
@@ -1,3 +1,1 @@
-ssh -i /home/user/.ssh/id_rsa user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh -i /home/user/.ssh/id_rsa user@example.com bash

--- a/tests/__snapshots__/SshTest__zero_is_a_valid_port_number__1.txt
+++ b/tests/__snapshots__/SshTest__zero_is_a_valid_port_number__1.txt
@@ -1,3 +1,1 @@
-ssh -p 0 user@example.com 'bash -se' << \EOF-SPATIE-SSH
-whoami
-EOF-SPATIE-SSH
+ssh -p 0 user@example.com bash


### PR DESCRIPTION
Windows cannot handle the `<<` very well, so this pull request will change the command that is executed, so that it is Windows compatible.