### PR TITLE
Multiplexing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Alternatively you can use the `usePort` function:
 Ssh::create('user', 'host')->usePort($port);
 ```
 
+### Specifying a jump host
+
+If using a jump/proxy/bastion host, the `useJumpHost` function allows you to set the jump hosts details:
+
+```php
+Ssh::create('user', 'host')->useJumpHost("$jumpuser@$jumphost:$jumpport");
+```
+
 ### Specifying the private key to use
 
 You can use `usePrivateKey` to specify a path to a private SSH key to use.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ If using a jump/proxy/bastion host, the `useJumpHost` function allows you to set
 Ssh::create('user', 'host')->useJumpHost("$jumpuser@$jumphost:$jumpport");
 ```
 
+### Using SSH multiplexing
+
+If making many connections to the same host, SSH multiplexing enables re-using one TCP connection. Call `useMultiplexing` function to set control master options:
+
+```php
+Ssh::create('user', 'host')->useMultiplexing($controlPath, $controlPersist);
+
+// Ssh::create('user', 'host')->useMultiplexing('/home/.ssh/control_masters/%C', '15m');
+
+```
+
+
 ### Specifying the private key to use
 
 You can use `usePrivateKey` to specify a path to a private SSH key to use.

--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -62,6 +62,12 @@ class Ssh
         return $this;
     }
 
+    public function useMultiplexing(string $controlPath, string $controlPersist = '10m'):self
+    {
+        $this->extraOptions['control_master'] = '-o ControlMaster=auto -o ControlPath=' . $controlPath . ' -o ControlPersist=' . $controlPersist;
+        return $this;
+    }
+
     public function configureProcess(Closure $processConfigurationClosure): self
     {
         $this->processConfigurationClosure = $processConfigurationClosure;

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -62,6 +62,14 @@ class SshTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_the_multiplex_path_via_the_dedicated_function()
+    {
+        $command = (new Ssh('user', 'example.com'))->useMultiplexing('/home/test/control_masters/%C', '15m')->getExecuteCommand('whoami');
+
+        $this->assertMatchesSnapshot($command);
+    }
+
+    /** @test */
     public function it_can_instantiate_via_the_create_method()
     {
         $this->assertInstanceOf(Ssh::class, Ssh::create('user', 'example.com'));

--- a/tests/__snapshots__/SshTest__it_can_set_the_multiplex_path_via_the_dedicated_function__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_set_the_multiplex_path_via_the_dedicated_function__1.txt
@@ -1,0 +1,3 @@
+ssh -o ControlMaster=auto -o ControlPath=/home/test/control_masters/%C -o ControlPersist=15m user@example.com 'bash -se' << \EOF-SPATIE-SSH
+whoami
+EOF-SPATIE-SSH


### PR DESCRIPTION
This PR adds support for SSH multiplexing i.e. a way of re-using a TCP connection if making multiple connections to the same host.