### PR TITLE
Allow to run ssh commands to localhost #105

### DIFF
--- a/src/Ssh.php
+++ b/src/Ssh.php
@@ -16,6 +16,8 @@ class Ssh
 
     protected bool $addBash;
 
+    protected bool $allowLocalConnection = false;
+
     protected Closure $processConfigurationClosure;
 
     protected Closure $onOutput;
@@ -138,6 +140,13 @@ class Ssh
         return $this;
     }
 
+    public function allowLocalConnection(): self
+    {
+        $this->allowLocalConnection = true;
+
+        return $this;
+    }
+
     public function addExtraOption(string $option): self
     {
         $this->extraOptions[] = $option;
@@ -163,7 +172,8 @@ class Ssh
 
         $commandString = implode(PHP_EOL, $commands);
 
-        if (in_array($this->host, ['local', 'localhost', '127.0.0.1'])) {
+        // Unless local SSH connections are allowed, execute command locally
+        if (!$this->allowLocalConnection && in_array($this->host, ['local', 'localhost', '127.0.0.1'])) {
             return $commandString;
         }
 

--- a/tests/SshTest.php
+++ b/tests/SshTest.php
@@ -104,6 +104,14 @@ it('can run a command locally', function () {
     expect(get_current_user())->toEqual(trim($command->getOutput()));
 });
 
+it('can run a remote command even locally', function () {
+    $local = new Ssh('user', '127.0.0.1');
+    $local->allowLocalConnection();
+
+    $command = $this->ssh->getExecuteCommand('whoami');
+    assertMatchesSnapshot($command);
+});
+
 it('can configure the used process', function () {
     $command = $this->ssh->configureProcess(function (Process $process) {
         $process->setTimeout(0);

--- a/tests/__snapshots__/SshTest__it_can_run_a_remote_command_even_locally__1.txt
+++ b/tests/__snapshots__/SshTest__it_can_run_a_remote_command_even_locally__1.txt
@@ -1,0 +1,3 @@
+ssh  user@example.com 'bash -se' << \EOF-SPATIE-SSH
+whoami
+EOF-SPATIE-SSH


### PR DESCRIPTION
# Allow to run ssh commands to localhost #105

See #105 : for testing reasons, one could want to test a set of SSH commands to a local Docker container.

For this purpose, I'm suggesting the option `$allowLocalConnection`, by default remains set to `false`. It can be set using the _truey only_ setter `allowLocalConnection()`. If `true`, the check on local host that keeps the `$command` as a local one is disabled.